### PR TITLE
feature: add support for binding custom function to keys

### DIFF
--- a/lua/pckr/loader/keys.lua
+++ b/lua/pckr/loader/keys.lua
@@ -1,21 +1,31 @@
 --- @param mode string
 --- @param key string
+--- @param _rhs? string|fun()
+--- @param _opts? table
 --- @return fun(_: fun())
-return function(mode, key)
+return function(mode, key, _rhs, _opts)
+  if not _opts then
+    _opts = {
+      desc = 'pckr.nvim lazy load',
+      silent = true,
+    }
+  end
   --- @param loader fun()
   return function(loader)
     -- TODO(lewis6991): detect is mapping already exists
-    vim.keymap.set(mode, key, function()
-      vim.keymap.del(mode, key)
-      loader()
-      if mode == 'n' then
-        vim.api.nvim_input(key)
-      else
-        vim.api.nvim_feedkeys(key, mode, false)
-      end
-    end, {
-      desc = 'pckr.nvim lazy load',
-      silent = true,
-    })
+    -- TODO(Zhou-Yicheng): delete mapping if exists
+    -- vim.keymap.del(mode, key)
+    loader()
+    if _rhs then
+      vim.keymap.set(mode, key, _rhs, _opts)
+    else
+      vim.keymap.set(mode, key, function()
+        if mode == 'n' then
+          vim.api.nvim_input(key)
+        else
+          vim.api.nvim_feedkeys(key, mode, false)
+        end
+      end, _opts)
+    end
   end
 end


### PR DESCRIPTION
Add support for `rhs` and `opts` of `vim.keymap.set`

Test with following spec:
```lua
local keys = require('pckr.loader.keys')
require('pckr').add {
  {
    'folke/flash.nvim',
    cond = {
      keys({ 'n', 'x', 'o' }, 's', function() require('flash').jump() end, { desc = 'Flash' }),
      keys({ 'n', 'x', 'o' }, 'S', function() require('flash').treesitter() end, { desc = 'Flash Treesitter' }),
      keys({ 'o' }, 'r', function() require('flash').remote() end, { desc = 'Remote Flash' }),
      keys({ 'o', 'x' }, 'R', function() require('flash').treesitter_search() end, { desc = 'Treesitter Search' }),
      keys({ 'c' }, '<c-s>', function() require('flash').toggle() end, { desc = 'Toggle Flash Search' }),
    },
  }
}
```