### PR TITLE
Restore Neovim 0.9.5 compatibility

### DIFF
--- a/lua/pckr/fsstate.lua
+++ b/lua/pckr/fsstate.lua
@@ -38,7 +38,7 @@ local function get_dir_plugins(dir)
   for name, ty in vim.fs.dir(dir) do
     if ty ~= 'file' then
       local path = util.join_paths(dir, name)
-      if vim.uv.fs_stat(path) then
+      if uv.fs_stat(path) then
         plugins[path] = name
       end
     end

--- a/lua/pckr/plugin_types/local.lua
+++ b/lua/pckr/plugin_types/local.lua
@@ -1,5 +1,8 @@
 local a = require('pckr.async')
 local log = require('pckr.log')
+local util = require('pckr.util')
+
+local uv = vim.loop
 
 --- @class Pckr.PluginHandler.Local: Pckr.PluginHandler
 local M = {}
@@ -14,8 +17,8 @@ end
 --- @param disp Pckr.Display
 --- @return string?
 M.updater = a.sync(function(plugin, disp)
-  local gitdir = vim.fs.joinpath(plugin.install_path, '.git')
-  if vim.uv.fs_stat(gitdir) then
+  local gitdir = util.join_paths(plugin.install_path, '.git')
+  if uv.fs_stat(gitdir) then
     return require('pckr.plugin_types.git').updater(plugin, disp, true)
   end
   -- Nothing to do


### PR DESCRIPTION
It looks like some dependencies on Lua features only available on Neovim `master` have snuck in:

- Having `vim.uv` as an alias for `vim.loop`

- `vim.fs.joinpath`