### PR TITLE
fix command complete issues

### DIFF
--- a/lua/pckr/cli.lua
+++ b/lua/pckr/cli.lua
@@ -2,10 +2,20 @@ local log = require('pckr.log')
 
 local M = {}
 
+--- @param lead string
 --- @return string[]
-local function command_complete()
+local function command_complete(lead)
   local actions = require('pckr.actions')
-  return vim.tbl_keys(actions)
+  local completion_list = vim.tbl_filter(
+    --- @param name string
+    --- @return boolean
+    function(name)
+      return vim.startswith(name, lead)
+    end,
+    vim.tbl_keys(actions)
+  )
+  table.sort(completion_list)
+  return completion_list
 end
 
 -- Completion user plugins
@@ -36,7 +46,7 @@ function M.complete(arglead, line)
 
   local matches = {}
   if n == 2 then
-    matches = command_complete()
+    matches = command_complete(arglead)
   elseif n > 2 then
     matches = plugin_complete(arglead)
   end

--- a/lua/pckr/loader/cmd.lua
+++ b/lua/pckr/loader/cmd.lua
@@ -19,10 +19,10 @@ return function(cmd)
     end, {
       bang = true,
       nargs = '*',
-      complete = function()
+      complete = function(ArgLead, CmdLine, CursorPos)
         vim.api.nvim_del_user_command(cmd)
         loader()
-        return vim.fn.getcompletion(cmd .. ' ', 'cmdline')
+        return vim.fn.getcompletion(cmd .. ' ' .. ArgLead, 'cmdline')
       end,
     })
   end

--- a/lua/pckr/loader/cmd.lua
+++ b/lua/pckr/loader/cmd.lua
@@ -19,10 +19,10 @@ return function(cmd)
     end, {
       bang = true,
       nargs = '*',
-      complete = function(ArgLead, CmdLine, CursorPos)
+      complete = function(arg_lead, cmd_line, cursor_pos)
         vim.api.nvim_del_user_command(cmd)
         loader()
-        return vim.fn.getcompletion(CmdLine, 'cmdline')
+        return vim.fn.getcompletion(cmd_line, 'cmdline')
       end,
     })
   end

--- a/lua/pckr/loader/cmd.lua
+++ b/lua/pckr/loader/cmd.lua
@@ -22,7 +22,7 @@ return function(cmd)
       complete = function(ArgLead, CmdLine, CursorPos)
         vim.api.nvim_del_user_command(cmd)
         loader()
-        return vim.fn.getcompletion(cmd .. ' ' .. ArgLead, 'cmdline')
+        return vim.fn.getcompletion(CmdLine, 'cmdline')
       end,
     })
   end


### PR DESCRIPTION
Fix these issues:

1. `:Pckr st<Tab>` " will clear st
2. `:Telescope buf<Tab>` " will clear buf when Telescope was cond loaded by cmd('Telescope')