### PR TITLE
feat: simply re-issue the event for event cond load plugins

### DIFF
--- a/lua/pckr/loader/event.lua
+++ b/lua/pckr/loader/event.lua
@@ -12,9 +12,9 @@ return function(events, pattern)
         if done then
           return true
         end
+        -- HACK: work-around for https://github.com/neovim/neovim/issues/25526
         done = true
         loader()
-        -- TODO(lewis6991): should we re-issue the event? (#1163)
         vim.api.nvim_exec_autocmds(ev.event, {
           buffer = ev.buf,
           group = ev.group,

--- a/lua/pckr/loader/event.lua
+++ b/lua/pckr/loader/event.lua
@@ -3,14 +3,24 @@
 --- @return fun(_: fun())
 return function(events, pattern)
   return function(loader)
+    local done = false
     vim.api.nvim_create_autocmd(events, {
       pattern = pattern,
       once = true,
       desc = 'pckr.nvim lazy load',
-      callback = function()
+      callback = function(ev)
+        if done then
+          return true
+        end
+        done = true
         loader()
         -- TODO(lewis6991): should we re-issue the event? (#1163)
-        -- vim.api.nvim_exec_autocmds(event, { modeline = false })
+        vim.api.nvim_exec_autocmds(ev.event, {
+          buffer = ev.buf,
+          group = ev.group,
+          modeline = false,
+          data = ev.data,
+        })
       end,
     })
   end


### PR DESCRIPTION
I referred to lazy.nvim's event based lazy loading implementation (https://github.com/folke/lazy.nvim/blob/main/lua/lazy/core/handler/event.lua#L161) and implemented event re-issue in pckr.

Without this feature, many plugins based on event loading will encounter problems (eg. `InsertEnter`).

For example:
```lua
      {
        --'hrsh7th/nvim-cmp',
        'epheien/nvim-cmp',
        requires = {
          'hrsh7th/cmp-nvim-lsp',
          'onsails/lspkind.nvim',
          'hrsh7th/cmp-buffer',
          'hrsh7th/cmp-path',
          'epheien/cmp-cmdline',
          'L3MON4D3/LuaSnip',
          'saadparwaiz1/cmp_luasnip',
          'rafamadriz/friendly-snippets',
        },
        cond = {event({'InsertEnter'}), keys('n', ';', ':'), keys('n', '/'), keys('n', '?'), cmd('CmpDisable')},
        config = function()
          require('config/nvim-cmp')
        end,
      };
```