### PR TITLE
fix: loader.event CATS

### DIFF
--- a/lua/pckr/loader/event.lua
+++ b/lua/pckr/loader/event.lua
@@ -1,4 +1,4 @@
---- @param events string[]
+--- @param events string|string[]
 --- @param pattern string?
 --- @return fun(_: fun())
 return function(events, pattern)


### PR DESCRIPTION
Fix function CATS to avoid lsp errors.

`:h nvim_create_autocmd()`
```vimhelp
    Parameters: ~
      • {event}  (string|array) Event(s) that will trigger the handler
                 (`callback` or `command`).
```