### PR TITLE
fix: #33

### DIFF
--- a/lua/pckr/loader.lua
+++ b/lua/pckr/loader.lua
@@ -122,7 +122,7 @@ local function packadd(plugin)
     return
   end
 
-  if vim.v.vim_did_enter ~= 1 and not plugin.cond then
+  if vim.v.vim_did_enter ~= 1 and not vim.fn.expand('<amatch>') then
     -- Do not source. We've already added to rtp, so no need to do anything.
     return
   end

--- a/lua/pckr/loader.lua
+++ b/lua/pckr/loader.lua
@@ -122,7 +122,7 @@ local function packadd(plugin)
     return
   end
 
-  if vim.v.vim_did_enter ~= 1 then
+  if vim.v.vim_did_enter ~= 1 and not plugin.cond then
     -- Do not source. We've already added to rtp, so no need to do anything.
     return
   end


### PR DESCRIPTION
plugin/* will not loaded when it modify rtp in autocmd, such as:
```vim
autocmd FileType * ++once set rtp+=~/myconf/vim/pckr/opt/nvim-lspconfig
```

so pckr need to load them

I try to use `not vim.tbl_isempty(vim.v.event)` check if in autocmd context, but it failed, seems it is a bug of nvim