### PR TITLE
Fix vim.uv not existing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ add the following snippet somewhere in your config **before** your first usage o
 local function bootstrap_pckr()
   local pckr_path = vim.fn.stdpath("data") .. "/pckr/pckr.nvim"
 
-  if not vim.uv.fs_stat(pckr_path) then
+  if not (vim.uv or vim.loop).fs_stat(pckr_path) then
     vim.fn.system({
       'git',
       'clone',


### PR DESCRIPTION
User may not have uv installed either; this prevents that situation as well.