### PR TITLE
feat: cmd loader add range attribute

### DIFF
--- a/lua/pckr/loader/cmd.lua
+++ b/lua/pckr/loader/cmd.lua
@@ -19,6 +19,7 @@ return function(cmd)
     end, {
       bang = true,
       nargs = '*',
+      range = true,
       complete = function(_arg_lead, cmd_line, _cursor_pos)
         vim.api.nvim_del_user_command(cmd)
         loader()


### PR DESCRIPTION
The following configuration will directly report an error when used for the first time before this new feature is added.

eg. `:'<,'>Format<CR>`

```lua
{
    'stevearc/conform.nvim',
    cond = cmd('Format'),
    config = function()
      local conform = require('conform')
      conform.setup({
        formatters_by_ft = {
          lua = { lsp_format = 'prefer' },
          cpp = { 'clang-format' },
        },
        format_on_save = function() end,
        format_after_save = function() end,
      })

      vim.api.nvim_create_user_command("Format", function(args)
        local range = nil
        if args.count ~= -1 then
          local end_line = vim.api.nvim_buf_get_lines(0, args.line2 - 1, args.line2, true)[1]
          range = {
            start = { args.line1, 0 },
            ["end"] = { args.line2, end_line:len() },
          }
        end
        conform.format({ async = true, lsp_format = "fallback", range = range })
      end, { range = true })
    end
  }
```